### PR TITLE
Fix typos in model docstrings

### DIFF
--- a/src/models/dgnn.py
+++ b/src/models/dgnn.py
@@ -1,5 +1,5 @@
 """
-Defining Dyanmics LSTM-GNN models
+Defining Dynamic LSTM-GNN models
 """
 import torch
 import torch.nn as nn

--- a/src/models/lstm.py
+++ b/src/models/lstm.py
@@ -77,7 +77,7 @@ class DynamicLSTM(nn.Module):
         init hidden state for LSTM 
         note to self:
         - this function seems unnecessary since nn.LSTM defaults to initialize with zeroes anyway.
-        - weight.new creates a Varialbe with the same data type as weight (i.e. nth actually to do with weight)
+        - weight.new creates a Variable with the same data type as weight (i.e., nothing actually to do with weight)
         - init_hidden doesn't initialize the weights, rather, it creates new initial states for new sequences (t=0)
         """
         weight = next(self.parameters()).data


### PR DESCRIPTION
## Summary
- correct 'Dyanmics' typo in DGNN docstring
- fix misspelled 'Variable' in LSTM comments

## Testing
- `python -m py_compile src/models/dgnn.py src/models/lstm.py`

------
https://chatgpt.com/codex/tasks/task_e_6841397d1cc88322a97239703c200d92