### PR TITLE
Enable test mode for preprocessing

### DIFF
--- a/eICU_preprocessing/run_all_preprocessing.py
+++ b/eICU_preprocessing/run_all_preprocessing.py
@@ -15,7 +15,7 @@ if __name__=='__main__':
     except FileNotFoundError:
         pass
     cut_off_prevalence = 0.01  # this would be 1%
-    timeseries_main(eICU_path, test=False)
+    timeseries_main(eICU_path, test=True)
     diagnoses_main(eICU_path, cut_off_prevalence)
     flat_and_labels_main(eICU_path)
-    split_train_test(eICU_path, is_test=False)
+    split_train_test(eICU_path, is_test=True)


### PR DESCRIPTION
## Summary
- speed up pre-processing for experimentation by enabling test mode in `run_all_preprocessing.py`

## Testing
- `pip install -r requirements.txt` *(fails: metadata-generation-failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6842c6e784d0832297a7804513b9247c