### PR TITLE
Fix diagnosis slicing bug

### DIFF
--- a/src/dataloader/ts_reader.py
+++ b/src/dataloader/ts_reader.py
@@ -44,7 +44,7 @@ def collect_ts_flat_labels(data_dir, ts_mask, task, add_diag, split=None,
 
     if add_diag:
         diag_data, diag_info = read_mm(data_dir, 'diagnoses')
-        diag = slice_data(diag_data, flat_info, split)
+        diag = slice_data(diag_data, diag_info, split)
         if split_flat_and_diag:
             flat = (flat, diag)
         else:


### PR DESCRIPTION
## Summary
- slice the diagnoses dataset using its own metadata when building temporal data

## Testing
- `python -m py_compile src/dataloader/ts_reader.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6841387fe0248322b5d6b271377241f8